### PR TITLE
Fix get_latents_path function frame counter

### DIFF
--- a/run_tokenflow_pnp.py
+++ b/run_tokenflow_pnp.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import re
 import numpy as np
 import cv2
 from pathlib import Path
@@ -115,7 +116,10 @@ class TokenFlow(nn.Module):
         latents_path = os.path.join(config["latents_path"], f'sd_{config["sd_version"]}',
                              Path(config["data_path"]).stem, f'steps_{config["n_inversion_steps"]}')
         latents_path = [x for x in glob.glob(f'{latents_path}/*') if '.' not in Path(x).name]
-        n_frames = [int([x for x in latents_path[i].split('/') if 'nframes' in x][0].split('_')[1]) for i in range(len(latents_path))]
+        
+        pattern = re.compile(".*nframes_([0-9]+)")
+        n_frames = [int(g[1]) for g in [pattern.match(latents_path[i]) for i in range(len(latents_path))] if g]
+
         latents_path = latents_path[np.argmax(n_frames)]
         self.config["n_frames"] = min(max(n_frames), config["n_frames"])
         if self.config["n_frames"] % self.config["batch_size"] != 0:


### PR DESCRIPTION
## What
Fix a frame counter in get_latents_path function

## Why
I was getting an error when the function tried to get the number of frames.

## Description
```bat
Traceback (most recent call last):
  File "C:\Projetos\TokenFlow\run_tokenflow_pnp.py", line 304, in <module>
    run(config)
  File "C:\Projetos\TokenFlow\run_tokenflow_pnp.py", line 283, in run
    editor = TokenFlow(config)
  File "C:\Projetos\TokenFlow\run_tokenflow_pnp.py", line 61, in __init__
    self.latents_path = self.get_latents_path()
  File "C:\Projetos\TokenFlow\run_tokenflow_pnp.py", line 122, in get_latents_path
    n_frames = [int([x for x in latents_path[i].split('/') if 'nframes' in x][0].split('_')[1]) for i in range(len(latents_path))]
  File "C:\Projetos\TokenFlow\run_tokenflow_pnp.py", line 122, in <listcomp>
    n_frames = [int([x for x in latents_path[i].split('/') if 'nframes' in x][0].split('_')[1]) for i in range(len(latents_path))]
ValueError: invalid literal for int() with base 10: '2.1\\woman-running\\steps'
```