### PR TITLE
Exclude virtual environment directories and cache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 .DS_Store
+__pycache__/
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+*.pth


### PR DESCRIPTION
In most cases, developers will use venv to quickly create virtual environments, and running programs will generate pycache. In order to improve the development efficiency of contributors, I think may be can exclude venv and pycache directories